### PR TITLE
Fix point symbols with next

### DIFF
--- a/src/ts/widget/GlTFWidget.tsx
+++ b/src/ts/widget/GlTFWidget.tsx
@@ -48,7 +48,7 @@ export default class GlTFWidget extends declared(DrawWidget) {
 
   public postInitialize() {
     this.layer.elevationInfo = {
-      mode: "relative-to-ground",
+      mode: "on-the-ground",
     };
     this.watch("progress", (value) => this.toggleLoadingIndicator(true, "Importing " + value + "%"));
   }

--- a/src/ts/widget/SymbolGallery.tsx
+++ b/src/ts/widget/SymbolGallery.tsx
@@ -67,7 +67,7 @@ export default class SymbolGallery extends declared(DrawWidget) {
 
   public postInitialize() {
     this.layer.elevationInfo = {
-      mode: "relative-to-ground",
+      mode: "on-the-ground",
     };
 
     if (!this.groups.length) {

--- a/src/ts/widget/operation/DrawGeometry.ts
+++ b/src/ts/widget/operation/DrawGeometry.ts
@@ -104,7 +104,7 @@ export default class DrawGeometry<G extends Geometry> extends WidgetOperation {
         sketchGraphic.geometry.hasZ = false;
       }
 
-      sketchViewModel.update(sketchGraphic, { tool: "reshape" });
+      sketchViewModel.update(sketchGraphic, { tool: this.geometryType === "point" ? "transform" : "reshape" });
 
       if (hasZ) {
         sketchGraphic.geometry = lastGeometry;


### PR DESCRIPTION
2 Fixes to make the app more usable with next:
* Use relative to ground for point symbols. (Unfortunately this makes icons draped, but at least they work)
* Use transform tool for point symbols